### PR TITLE
fix: let hero hover animate across the full area

### DIFF
--- a/src/app/(en)/HomePageClient.tsx
+++ b/src/app/(en)/HomePageClient.tsx
@@ -271,7 +271,15 @@ export default function HomePageClient({
               <CalligraphyPattern isDark={isDark} />
               <div className="relative z-[2] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full pointer-events-none">
                 <div className="max-w-3xl mx-auto text-center space-y-8">
+                  {/*
+                    * data-calligraphy-avoid-text / data-calligraphy-avoid-buttons:
+                    * CalligraphyPattern uses these elements' bounding boxes as
+                    * per-element exclusion zones on mobile so random pulses never
+                    * fire directly behind the headline/subtitle or the CTA buttons.
+                    * Desktop hover is unrestricted and ignores these attributes.
+                    */}
                   <motion.h1
+                    data-calligraphy-avoid-text
                     initial={{ opacity: 0, y: 30 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.1 }}
@@ -282,6 +290,7 @@ export default function HomePageClient({
                   </motion.h1>
 
                   <motion.p
+                    data-calligraphy-avoid-text
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.2 }}
@@ -292,6 +301,7 @@ export default function HomePageClient({
                   </motion.p>
 
                   <motion.div
+                    data-calligraphy-avoid-buttons
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.3 }}

--- a/src/app/(en)/HomePageClient.tsx
+++ b/src/app/(en)/HomePageClient.tsx
@@ -269,21 +269,8 @@ export default function HomePageClient({
           <>
             <section className="relative min-h-[90vh] flex items-center pt-20 overflow-hidden">
               <CalligraphyPattern isDark={isDark} />
-              {/*
-                * pointer-events-none on the content wrapper so mouse events
-                * pass through to the calligraphy layer below (z-[1]).
-                * Buttons re-enable pointer-events-auto individually.
-                */}
               <div className="relative z-[2] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full pointer-events-none">
-                {/*
-                  * data-calligraphy-avoid: CalligraphyPattern uses this
-                  * element's bounding box as an exclusion zone so animated
-                  * strokes never cross through the headline, subtitle, or CTAs.
-                  */}
-                <div
-                  data-calligraphy-avoid
-                  className="max-w-3xl mx-auto text-center space-y-8"
-                >
+                <div className="max-w-3xl mx-auto text-center space-y-8">
                   <motion.h1
                     initial={{ opacity: 0, y: 30 }}
                     animate={{ opacity: 1, y: 0 }}

--- a/src/components/CalligraphyPattern.tsx
+++ b/src/components/CalligraphyPattern.tsx
@@ -40,6 +40,48 @@ const MOBILE_INTERVAL_MAX = 2200;
 /** Mobile: delay before first pulse after mount. */
 const MOBILE_INITIAL_DELAY = 350;
 
+/**
+ * Mobile only — minimum rendered area (CSS px²) a glyph must have to be
+ * eligible for a random pulse. Keeps animations on the big, legible letters
+ * and skips tiny connector strokes.
+ */
+const MOBILE_MIN_GLYPH_AREA = 4000;
+
+/**
+ * Selectors for the elements whose exact bounding boxes should block mobile
+ * pulses. Keeping this to the actual text lines and CTA buttons means the
+ * exclusion is as tight as possible — no large invisible rectangle.
+ */
+const MOBILE_AVOID_SELECTORS = [
+  "[data-calligraphy-avoid-text]",
+  "[data-calligraphy-avoid-buttons]",
+];
+
+type Rect = { left: number; right: number; top: number; bottom: number };
+
+/** Collect the current viewport rects of every avoid element. */
+function getMobileAvoidRects(): Rect[] {
+  const rects: Rect[] = [];
+  for (const sel of MOBILE_AVOID_SELECTORS) {
+    for (const el of document.querySelectorAll(sel)) {
+      const r = el.getBoundingClientRect();
+      if (r.width > 0 && r.height > 0) rects.push(r);
+    }
+  }
+  return rects;
+}
+
+function overlapsAny(
+  a: Pick<DOMRectReadOnly, "left" | "right" | "top" | "bottom">,
+  rects: Rect[],
+): boolean {
+  for (const b of rects) {
+    if (!(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom))
+      return true;
+  }
+  return false;
+}
+
 interface CalligraphyPatternProps {
   isDark: boolean;
 }
@@ -213,10 +255,13 @@ export default function CalligraphyPattern({ isDark }: CalligraphyPatternProps) 
     };
   }, []);
 
-  /* ── Mobile: random pulses, skipping the hero-text bounding box ── */
+  /* ── Mobile: random pulses, large glyphs only, skipping text/button rects ── */
   const animateRandom = useCallback(() => {
     const svg = svgRef.current;
     if (!svg) return;
+
+    // Recompute per-tick so we handle scroll/resize without an observer.
+    const avoidRects = getMobileAvoidRects();
 
     const accents = svg.querySelectorAll<SVGPathElement>(".cal-accent");
     const visible: SVGPathElement[] = [];
@@ -232,11 +277,15 @@ export default function CalligraphyPattern({ isDark }: CalligraphyPatternProps) 
       }
       const r = el.getBoundingClientRect();
       if (r.width === 0 || r.height === 0) continue;
+      // Skip small connector strokes — only animate large glyphs.
+      if (r.width * r.height < MOBILE_MIN_GLYPH_AREA) continue;
       const cx = r.left + r.width / 2;
       const cy = r.top + r.height / 2;
       // Central 80% horizontally, within viewport vertically
       if (cx < vw * 0.1 || cx > vw * 0.9) continue;
       if (cy < 0 || cy > vh) continue;
+      // Skip any glyph whose bounding box overlaps an avoid element.
+      if (overlapsAny(r, avoidRects)) continue;
       visible.push(el);
     }
 

--- a/src/components/CalligraphyPattern.tsx
+++ b/src/components/CalligraphyPattern.tsx
@@ -40,55 +40,8 @@ const MOBILE_INTERVAL_MAX = 2200;
 /** Mobile: delay before first pulse after mount. */
 const MOBILE_INITIAL_DELAY = 350;
 
-/**
- * Padding (CSS px) around the hero text exclusion rect.
- * Accents whose center falls within [rect + pad] are skipped so
- * animations never cross through the headline or CTAs.
- */
-const TEXT_EXCLUSION_PAD = 24;
-
-/**
- * Selector identifying the hero-text container whose bounding box
- * should never host an animated accent. The host page marks that
- * element with `data-calligraphy-avoid`.
- */
-const TEXT_AVOID_SELECTOR = "[data-calligraphy-avoid]";
-
 interface CalligraphyPatternProps {
   isDark: boolean;
-}
-
-type ExclusionRect = {
-  left: number;
-  right: number;
-  top: number;
-  bottom: number;
-};
-
-function getTextExclusionRect(): ExclusionRect | null {
-  const avoidEl = document.querySelector(TEXT_AVOID_SELECTOR);
-  if (!avoidEl) return null;
-
-  const r = avoidEl.getBoundingClientRect();
-  return {
-    left: r.left - TEXT_EXCLUSION_PAD,
-    right: r.right + TEXT_EXCLUSION_PAD,
-    top: r.top - TEXT_EXCLUSION_PAD,
-    bottom: r.bottom + TEXT_EXCLUSION_PAD,
-  };
-}
-
-function rectsIntersect(
-  a: Pick<DOMRectReadOnly, "left" | "right" | "top" | "bottom">,
-  b: ExclusionRect | null,
-) {
-  if (!b) return false;
-  return !(
-    a.right < b.left ||
-    a.left > b.right ||
-    a.bottom < b.top ||
-    a.top > b.bottom
-  );
 }
 
 function clearTimerSet(timerIds: Set<number>) {
@@ -107,11 +60,6 @@ function scheduleTrackedTimeout(
   }, delay);
   timerIds.add(id);
   return id;
-}
-
-function pointInsideRect(x: number, y: number, rect: ExclusionRect | null) {
-  if (!rect) return false;
-  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
 }
 
 export default function CalligraphyPattern({ isDark }: CalligraphyPatternProps) {
@@ -205,12 +153,6 @@ export default function CalligraphyPattern({ isDark }: CalligraphyPatternProps) 
       const target = e.target as Element;
       if (!target?.classList?.contains("cal-base")) return;
 
-      // Desktop should honor the same exclusion zone as mobile so
-      // hover-driven reveals never light up strokes directly under
-      // the headline, subtitle, or CTA block.
-      const targetRect = target.getBoundingClientRect();
-      if (rectsIntersect(targetRect, getTextExclusionRect())) return;
-
       const glyph = target.closest(".cal-glyph");
       if (!glyph) return;
 
@@ -276,10 +218,6 @@ export default function CalligraphyPattern({ isDark }: CalligraphyPatternProps) 
     const svg = svgRef.current;
     if (!svg) return;
 
-    // Recompute the exclusion rect each tick — handles resize + scroll
-    // without a dedicated ResizeObserver.
-    const avoid = getTextExclusionRect();
-
     const accents = svg.querySelectorAll<SVGPathElement>(".cal-accent");
     const visible: SVGPathElement[] = [];
     const vw = window.innerWidth;
@@ -299,11 +237,6 @@ export default function CalligraphyPattern({ isDark }: CalligraphyPatternProps) 
       // Central 80% horizontally, within viewport vertically
       if (cx < vw * 0.1 || cx > vw * 0.9) continue;
       if (cy < 0 || cy > vh) continue;
-      // Exclude the hero-text bounding box (+ padding) so animations
-      // never cross through the headline, subtitle, or CTA buttons.
-      if (rectsIntersect(r, avoid)) {
-        continue;
-      }
       visible.push(el);
     }
 


### PR DESCRIPTION
## Summary
- Remove the hero text exclusion box that blocked the background hover animation
- Allow the calligraphy hover effect to work across the full hero area in the shared home page client

## Notes
- This affects both English and Arabic home routes because they share the same client component