### PR TITLE
fix Arabic timeline alternation

### DIFF
--- a/src/app/(en)/HomePageClient.tsx
+++ b/src/app/(en)/HomePageClient.tsx
@@ -426,21 +426,29 @@ export default function HomePageClient({
                     className={`absolute ${isRtl ? "right-4 md:right-1/2" : "left-4 md:left-1/2"} top-0 bottom-0 w-px bg-[#008a2f]/30`}
                   />
                   {t.timeline.map((event, i) => {
-                    const isLeft = i % 2 === 0;
+                    const isRightSide = isRtl ? i % 2 === 0 : i % 2 !== 0;
+                    const justifyClass = isRightSide
+                      ? isRtl
+                        ? "justify-start"
+                        : "justify-end"
+                      : isRtl
+                        ? "justify-end"
+                        : "justify-start";
+
                     return (
                       <motion.div
                         key={i}
-                        initial={{ opacity: 0, x: isLeft ? -30 : 30 }}
+                        initial={{ opacity: 0, x: isRightSide ? 30 : -30 }}
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
                         transition={{ delay: i * 0.08 }}
-                        className={`relative flex items-start mb-8 md:${isLeft ? "justify-start" : "justify-end"}`}
+                        className={`relative flex items-start mb-8 md:${justifyClass}`}
                       >
                         <div
                           className={`absolute ${isRtl ? "right-3 md:right-[calc(50%-5px)]" : "left-3 md:left-[calc(50%-5px)]"} top-2 w-2.5 h-2.5 bg-[#008a2f] border-2 border-black z-10`}
                         />
                         <div
-                          className={`${isRtl ? "mr-12 md:mr-0" : "ml-12 md:ml-0"} md:w-[45%] ${!isLeft ? "md:ml-auto" : ""}`}
+                          className={`${isRtl ? "mr-12 md:mr-0" : "ml-12 md:ml-0"} md:w-[45%]`}
                         >
                           <CyberCard
                             isDark={isDark}

--- a/src/app/(en)/HomePageClient.tsx
+++ b/src/app/(en)/HomePageClient.tsx
@@ -422,18 +422,11 @@ export default function HomePageClient({
                   lang={lang}
                 />
                 <div className="relative">
-                  <div
-                    className={`absolute ${isRtl ? "right-4 md:right-1/2" : "left-4 md:left-1/2"} top-0 bottom-0 w-px bg-[#008a2f]/30`}
-                  />
+                  <div className="absolute left-1/2 top-0 bottom-0 w-px -translate-x-1/2 bg-[#008a2f]/30" />
                   {t.timeline.map((event, i) => {
                     const isRightSide = isRtl ? i % 2 === 0 : i % 2 !== 0;
-                    const justifyClass = isRightSide
-                      ? isRtl
-                        ? "justify-start"
-                        : "justify-end"
-                      : isRtl
-                        ? "justify-end"
-                        : "justify-start";
+                    const cardColumnClass = isRightSide ? "col-start-3" : "col-start-1";
+                    const cardAlignClass = isRightSide ? "justify-self-start" : "justify-self-end";
 
                     return (
                       <motion.div
@@ -442,13 +435,13 @@ export default function HomePageClient({
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
                         transition={{ delay: i * 0.08 }}
-                        className={`relative flex items-start mb-8 md:${justifyClass}`}
+                        className="relative grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-start mb-8"
                       >
                         <div
-                          className={`absolute ${isRtl ? "right-3 md:right-[calc(50%-5px)]" : "left-3 md:left-[calc(50%-5px)]"} top-2 w-2.5 h-2.5 bg-[#008a2f] border-2 border-black z-10`}
+                          className="col-start-2 mt-2 w-2.5 h-2.5 justify-self-center bg-[#008a2f] border-2 border-black z-10"
                         />
                         <div
-                          className={`${isRtl ? "mr-12 md:mr-0" : "ml-12 md:ml-0"} md:w-[45%]`}
+                          className={`${cardColumnClass} ${cardAlignClass} w-full max-w-[min(100vw-4rem,28rem)] px-4 sm:px-0`}
                         >
                           <CyberCard
                             isDark={isDark}


### PR DESCRIPTION
## Summary
- Rework the timeline into a centered 3-column grid so Arabic cards alternate left/right correctly on all breakpoints.
- Preserve the existing English behavior while fixing the RTL mobile collapse.

## Verification
- `npm run build`

## Notes
- Screenshot generation was not possible in this shell because no browser binary / Playwright runtime is available.