### PR TITLE
fix: alternate timeline cards correctly in RTL/Arabic desktop layout

### DIFF
--- a/src/app/(en)/HomePageClient.tsx
+++ b/src/app/(en)/HomePageClient.tsx
@@ -424,7 +424,7 @@ export default function HomePageClient({
                           className={`absolute ${isRtl ? "right-3 md:right-[calc(50%-5px)]" : "left-3 md:left-[calc(50%-5px)]"} top-2 w-2.5 h-2.5 bg-[#008a2f] border-2 border-black z-10`}
                         />
                         <div
-                          className={`${isRtl ? "mr-12 md:mr-0" : "ml-12 md:ml-0"} md:w-[45%] ${!isLeft ? "md:ml-auto" : ""}`}
+                          className={`${isRtl ? "mr-12 md:mr-0" : "ml-12 md:ml-0"} md:w-[45%] ${!isLeft ? (isRtl ? "md:mr-auto" : "md:ml-auto") : ""}`}
                         >
                           <CyberCard
                             isDark={isDark}


### PR DESCRIPTION
## Problem

In the Arabic (RTL) layout, all timeline cards stacked on the right side instead of alternating left/right.

**Root cause:** The card for odd items uses `md:ml-auto` to push it to the right in LTR. But in RTL, `margin-left: auto` is a physical property — it fills the left margin and pushes the card to the **right**, overriding the `justify-end` on the flex container that was intended to place it on the **left**. This caused every card to appear on the right side in Arabic.

## Fix

One-line change in `HomePageClient.tsx`: use `md:mr-auto` for odd items when in RTL (fills the right margin → pushes card left), instead of always using `md:ml-auto`.

```diff
- className={`... md:w-[45%] ${!isLeft ? "md:ml-auto" : ""}`}
+ className={`... md:w-[45%] ${!isLeft ? (isRtl ? "md:mr-auto" : "md:ml-auto") : ""}`}
```

Mobile behavior is unchanged.

## Screenshots

### Arabic (RTL) — Fixed alternating layout
![Arabic timeline fixed](ar-timeline-fixed.png)

### English (LTR) — Reference (unchanged)
![English timeline reference](en-timeline-reference.png)