### PR TITLE
add static RSS feed generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 out/
 *.tsbuildinfo
 public/content/
+public/rss.xml
+public/en/rss.xml
 artifacts/
 
 # dependencies

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "node": ">=20.18.1"
   },
   "scripts": {
-    "dev": "tsx scripts/sync-content-assets.ts && tsx scripts/build-link-previews.ts && next dev --port ${PORT:-25211} --hostname 0.0.0.0",
-    "build": "tsx scripts/sync-content-assets.ts && tsx scripts/build-link-previews.ts && next build",
+    "dev": "tsx scripts/sync-content-assets.ts && tsx scripts/build-link-previews.ts && tsx scripts/generate-rss.ts && next dev --port ${PORT:-25211} --hostname 0.0.0.0",
+    "build": "tsx scripts/sync-content-assets.ts && tsx scripts/build-link-previews.ts && tsx scripts/generate-rss.ts && next build",
     "start": "node scripts/serve-static.mjs",
     "import:wordpress": "tsx scripts/import-wordpress.ts",
     "previews:refresh": "tsx scripts/build-link-previews.ts",

--- a/scripts/generate-rss.ts
+++ b/scripts/generate-rss.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+import { getAllPosts, getPostBySlug } from "../src/lib/markdown";
+import { buildRssXml, getRssFeedPath } from "../src/lib/rss";
+import type { Lang } from "../src/lib/locale";
+
+const root = process.cwd();
+const publicDir = path.join(root, "public");
+const langs: Lang[] = ["ar", "en"];
+
+function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+async function generateFeed(lang: Lang) {
+  const posts = await Promise.all(
+    getAllPosts(lang).map(async (post) => getPostBySlug(post.slug, lang)),
+  );
+  const publishedPosts = posts.filter((post): post is NonNullable<typeof post> => Boolean(post));
+  const feedPath = getRssFeedPath(lang);
+  const outputPath = path.join(publicDir, feedPath.replace(/^\//, ""));
+
+  ensureDir(path.dirname(outputPath));
+  fs.writeFileSync(outputPath, buildRssXml(lang, publishedPosts));
+}
+
+await Promise.all(langs.map((lang) => generateFeed(lang)));

--- a/scripts/generate-rss.ts
+++ b/scripts/generate-rss.ts
@@ -9,9 +9,7 @@ const publicDir = path.join(root, "public");
 const langs: Lang[] = ["ar", "en"];
 
 function ensureDir(dir: string) {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  fs.mkdirSync(dir, { recursive: true });
 }
 
 async function generateFeed(lang: Lang) {

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import type { PostFrontMatter } from "@/lib/markdown";
 import type { Lang } from "@/lib/locale";
+import { SITE_URL, getRssFeedPath } from "@/lib/rss";
 
-const SITE_URL = "https://aosus.org";
 const DEFAULT_OG_IMAGE = "/opengraph.jpg";
 
 const SITE_COPY = {
@@ -118,6 +118,9 @@ export function getPageMetadata(
     description: resolved.description,
     alternates: {
       canonical: pathname,
+      types: {
+        "application/rss+xml": getRssFeedPath(lang),
+      },
     },
     openGraph: {
       title: resolved.title,

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,160 @@
+import type { Post, PostFrontMatter } from "@/lib/markdown";
+import type { Lang } from "@/lib/locale";
+import { getLocalizedPath, getPostPath } from "@/lib/locale";
+
+export const SITE_URL = "https://aosus.org";
+
+const RSS_COPY = {
+  ar: {
+    title: "مدونة مجتمع أسس",
+    description: "أخبار ومقالات وتحديثات من مجتمع أسس.",
+    language: "ar",
+    feedPath: "/rss.xml",
+  },
+  en: {
+    title: "Aosus Blog",
+    description: "News, articles, and updates from the Aosus community.",
+    language: "en",
+    feedPath: "/en/rss.xml",
+  },
+} as const;
+
+const IMAGE_CONTENT_TYPES: Record<string, string> = {
+  ".avif": "image/avif",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+};
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function getAbsoluteUrl(pathname: string): string {
+  return new URL(pathname, SITE_URL).toString();
+}
+
+function formatRfc822Date(value: string): string | null {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toUTCString();
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function escapeCdata(value: string): string {
+  return value.replaceAll("]]>", "]]]]><![CDATA[>");
+}
+
+function absolutizeHtmlUrls(value: string): string {
+  return value.replace(
+    /\b(href|src)=(["'])(\/[^"']*)\2/g,
+    (_match, attribute: string, quote: string, pathname: string) =>
+      `${attribute}=${quote}${getAbsoluteUrl(pathname)}${quote}`,
+  );
+}
+
+function getImageContentType(imageUrl: string): string | null {
+  try {
+    const pathname = new URL(getAbsoluteUrl(imageUrl)).pathname.toLowerCase();
+
+    for (const [extension, contentType] of Object.entries(IMAGE_CONTENT_TYPES)) {
+      if (pathname.endsWith(extension)) {
+        return contentType;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function getPostUrl(post: Pick<PostFrontMatter, "lang" | "slug" | "wpType" | "wpId">): string {
+  return getAbsoluteUrl(
+    getPostPath(post.lang, post.slug, post.wpType === "post" && post.wpId === post.slug),
+  );
+}
+
+export function getRssFeedPath(lang: Lang): string {
+  return RSS_COPY[lang].feedPath;
+}
+
+export function getRssFeedUrl(lang: Lang): string {
+  return getAbsoluteUrl(getRssFeedPath(lang));
+}
+
+export function buildRssXml(lang: Lang, posts: Post[]): string {
+  const copy = RSS_COPY[lang];
+  const siteUrl = getAbsoluteUrl(getLocalizedPath(lang, "/"));
+  const blogUrl = getAbsoluteUrl(getLocalizedPath(lang, "/blog"));
+  const feedUrl = getRssFeedUrl(lang);
+  const lastBuildDate = posts
+    .map((post) => formatRfc822Date(post.date))
+    .find((value): value is string => Boolean(value)) ?? new Date().toUTCString();
+
+  const items = posts
+    .map((post) => {
+      const link = getPostUrl(post);
+      const pubDate = formatRfc822Date(post.date);
+      const description = post.excerpt || stripHtml(post.content);
+      const htmlContent = absolutizeHtmlUrls(post.content.trim());
+      const imageContentType = post.image ? getImageContentType(post.image) : null;
+
+      return [
+        "    <item>",
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${escapeXml(link)}</link>`,
+        `      <guid isPermaLink=\"true\">${escapeXml(link)}</guid>`,
+        `      <description>${escapeXml(description)}</description>`,
+        ...(pubDate ? [`      <pubDate>${pubDate}</pubDate>`] : []),
+        ...(post.author ? [`      <dc:creator><![CDATA[${escapeCdata(post.author)}]]></dc:creator>`] : []),
+        ...post.categories.map((category) => `      <category>${escapeXml(category)}</category>`),
+        ...post.tags.map((tag) => `      <category>${escapeXml(tag)}</category>`),
+        ...(post.image && imageContentType
+          ? [
+              `      <enclosure url=\"${escapeXml(getAbsoluteUrl(post.image))}\" type=\"${imageContentType}\" />`,
+            ]
+          : []),
+        ...(htmlContent
+          ? [
+              `      <content:encoded><![CDATA[${escapeCdata(htmlContent)}]]></content:encoded>`,
+            ]
+          : []),
+        "    </item>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/">',
+    "  <channel>",
+    `    <title>${escapeXml(copy.title)}</title>`,
+    `    <link>${escapeXml(blogUrl)}</link>`,
+    `    <description>${escapeXml(copy.description)}</description>`,
+    `    <language>${copy.language}</language>`,
+    `    <lastBuildDate>${lastBuildDate}</lastBuildDate>`,
+    `    <atom:link href=\"${escapeXml(feedUrl)}\" rel=\"self\" type=\"application/rss+xml\" />`,
+    `    <image><url>${escapeXml(getAbsoluteUrl("/favicon.ico"))}</url><title>${escapeXml(copy.title)}</title><link>${escapeXml(siteUrl)}</link></image>`,
+    items,
+    "  </channel>",
+    "</rss>",
+    "",
+  ].join("\n");
+}

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -128,7 +128,7 @@ export function buildRssXml(lang: Lang, posts: Post[]): string {
         ...post.tags.map((tag) => `      <category>${escapeXml(tag)}</category>`),
         ...(post.image && imageContentType
           ? [
-              `      <enclosure url=\"${escapeXml(getAbsoluteUrl(post.image))}\" type=\"${imageContentType}\" />`,
+              `      <enclosure url=\"${escapeXml(getAbsoluteUrl(post.image))}\" length=\"0\" type=\"${imageContentType}\" />`,
             ]
           : []),
         ...(htmlContent

--- a/test/rss.test.ts
+++ b/test/rss.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildRssXml, getRssFeedPath, getRssFeedUrl } from "../src/lib/rss";
+
+describe("rss", () => {
+  it("builds an RSS feed with locale-specific metadata and post links", () => {
+    const xml = buildRssXml("en", [
+      {
+        title: "Example post",
+        excerpt: "Feed excerpt",
+        image: "/content/blog/example/cover.png",
+        ogImage: "/content/blog/example/cover.png",
+        thumbnail: "/content/blog/example/thumb.png",
+        date: "2026-04-14",
+        author: "Aosus",
+        tags: ["news"],
+        categories: ["updates"],
+        slug: "example-post",
+        lang: "en",
+        content: "<p>Hello feed readers.</p>",
+      },
+    ] as any);
+
+    expect(xml).toContain("<title>Aosus Blog</title>");
+    expect(xml).toContain("<language>en</language>");
+    expect(xml).toContain('<atom:link href="https://aosus.org/en/rss.xml" rel="self" type="application/rss+xml" />');
+    expect(xml).toContain("<link>https://aosus.org/en/blog/example-post</link>");
+    expect(xml).toContain("<dc:creator><![CDATA[Aosus]]></dc:creator>");
+    expect(xml).toContain('<enclosure url="https://aosus.org/content/blog/example/cover.png" type="image/png" />');
+    expect(xml).toContain("<content:encoded><![CDATA[<p>Hello feed readers.</p>]]></content:encoded>");
+  });
+
+  it("uses root-level URLs for Arabic WordPress-style posts", () => {
+    const xml = buildRssXml("ar", [
+      {
+        title: "Arabic post",
+        excerpt: "Excerpt",
+        image: "/content/blog/example/cover.jpg",
+        ogImage: "/content/blog/example/cover.jpg",
+        date: "2026-04-14",
+        author: "Aosus",
+        tags: [],
+        categories: [],
+        slug: "1192",
+        lang: "ar",
+        wpId: "1192",
+        wpType: "post",
+        content: "<p>Arabic body</p>",
+      },
+    ] as any);
+
+    expect(xml).toContain("<link>https://aosus.org/1192</link>");
+  });
+
+  it("exposes stable feed paths and URLs", () => {
+    expect(getRssFeedPath("ar")).toBe("/rss.xml");
+    expect(getRssFeedPath("en")).toBe("/en/rss.xml");
+    expect(getRssFeedUrl("ar")).toBe("https://aosus.org/rss.xml");
+    expect(getRssFeedUrl("en")).toBe("https://aosus.org/en/rss.xml");
+  });
+});

--- a/test/rss.test.ts
+++ b/test/rss.test.ts
@@ -16,7 +16,7 @@ describe("rss", () => {
         categories: ["updates"],
         slug: "example-post",
         lang: "en",
-        content: "<p>Hello feed readers.</p>",
+        content: '<p>Hello <a href="/path">feed readers</a> and <img src="/img.png" alt="img" /></p>',
       },
     ] as any);
 
@@ -25,8 +25,10 @@ describe("rss", () => {
     expect(xml).toContain('<atom:link href="https://aosus.org/en/rss.xml" rel="self" type="application/rss+xml" />');
     expect(xml).toContain("<link>https://aosus.org/en/blog/example-post</link>");
     expect(xml).toContain("<dc:creator><![CDATA[Aosus]]></dc:creator>");
-    expect(xml).toContain('<enclosure url="https://aosus.org/content/blog/example/cover.png" type="image/png" />');
-    expect(xml).toContain("<content:encoded><![CDATA[<p>Hello feed readers.</p>]]></content:encoded>");
+    expect(xml).toContain('<enclosure url="https://aosus.org/content/blog/example/cover.png" length="0" type="image/png" />');
+    expect(xml).toContain('<content:encoded><![CDATA[');
+    expect(xml).toContain('href="https://aosus.org/path"');
+    expect(xml).toContain('src="https://aosus.org/img.png"');
   });
 
   it("uses root-level URLs for Arabic WordPress-style posts", () => {


### PR DESCRIPTION
## Summary
- generate locale-aware static RSS feeds during the existing prebuild pipeline so every blog post is published to exported XML
- include full post content, canonical post URLs, media enclosures, and feed autodiscovery metadata for RSS readers and automation tools
- cover the feed builder with tests and verify the exported site produces `/rss.xml` and `/en/rss.xml`

## Testing
- `pnpm test`
- `pnpm build`