### PR TITLE
Add /feed and /rss aliases for RSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,11 @@ out/
 *.tsbuildinfo
 public/content/
 public/rss.xml
+public/rss
+public/feed
 public/en/rss.xml
+public/en/rss
+public/en/feed
 artifacts/
 
 # dependencies

--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,15 @@
 /.well-known/matrix/*
   Content-Type: application/json
   Access-Control-Allow-Origin: *
+
+/rss
+  Content-Type: application/rss+xml; charset=utf-8
+
+/feed
+  Content-Type: application/rss+xml; charset=utf-8
+
+/en/rss
+  Content-Type: application/rss+xml; charset=utf-8
+
+/en/feed
+  Content-Type: application/rss+xml; charset=utf-8

--- a/scripts/generate-rss.ts
+++ b/scripts/generate-rss.ts
@@ -21,7 +21,12 @@ async function generateFeed(lang: Lang) {
   const outputPath = path.join(publicDir, feedPath.replace(/^\//, ""));
 
   ensureDir(path.dirname(outputPath));
-  fs.writeFileSync(outputPath, buildRssXml(lang, publishedPosts));
+  const xml = buildRssXml(lang, publishedPosts);
+  fs.writeFileSync(outputPath, xml);
+
+  for (const aliasPath of [outputPath.replace(/rss\.xml$/, "rss"), outputPath.replace(/rss\.xml$/, "feed")]) {
+    fs.writeFileSync(aliasPath, xml);
+  }
 }
 
 await Promise.all(langs.map((lang) => generateFeed(lang)));

--- a/scripts/serve-static.mjs
+++ b/scripts/serve-static.mjs
@@ -11,6 +11,7 @@ const contentTypes = new Map([
   [".js", "text/javascript; charset=utf-8"],
   [".css", "text/css; charset=utf-8"],
   [".json", "application/json; charset=utf-8"],
+  [".xml", "application/rss+xml; charset=utf-8"],
   [".svg", "image/svg+xml"],
   [".png", "image/png"],
   [".jpg", "image/jpeg"],
@@ -22,6 +23,12 @@ const contentTypes = new Map([
 ]);
 
 function contentTypeFor(filePath) {
+  const basename = path.basename(filePath);
+
+  if (basename === "rss" || basename === "feed") {
+    return "application/rss+xml; charset=utf-8";
+  }
+
   return contentTypes.get(path.extname(filePath)) || "application/octet-stream";
 }
 


### PR DESCRIPTION
## Summary
- Emit `public/feed` and `public/rss` alongside the existing RSS XML files so `/feed` and `/rss` resolve to the same content as `/rss.xml`
- Ignore the generated alias files in git to keep the worktree clean after builds

## Verification
- `pnpm test -- test/rss.test.ts`
- `pnpm build`