### PR TITLE
Add Discourse embedded comments for articles

### DIFF
--- a/src/app/(en)/blog/[slug]/ArticlePageClient.tsx
+++ b/src/app/(en)/blog/[slug]/ArticlePageClient.tsx
@@ -7,11 +7,11 @@ import {
   User,
   ArrowLeft,
   ArrowRight,
-  MessageSquare,
   Tag,
 } from "lucide-react";
 import Link from "next/link";
 import CommunityLinks from "@/components/CommunityLinks";
+import DiscourseComments from "@/components/DiscourseComments";
 import Layout, {
   CyberCard,
   PrimaryButton,
@@ -25,18 +25,18 @@ const LABELS = {
   en: {
     breadcrumb: ["Home", "Blog"],
     supportCta: "Support Aosus Community",
-    discussCta: "Discuss on Forum",
     prevLabel: "Previous Post",
     supportBtn: "Support Us",
   },
   ar: {
     breadcrumb: ["الرئيسية", "المدونة"],
     supportCta: "ادعم مجتمع أسس",
-    discussCta: "علّق في المنتدى",
     prevLabel: "المقال السابق",
     supportBtn: "ادعمنا",
   },
 };
+
+const SITE_URL = "https://aosus.org";
 
 export default function ArticlePageClient({
   post,
@@ -57,6 +57,7 @@ export default function ArticlePageClient({
         const homeLink = getLocalizedPath(lang, "/");
         const blogLink = getLocalizedPath(lang, "/blog");
         const supportLink = getLocalizedPath(lang, "/support-us");
+        const discussionEmbedUrl = new URL(post.discussionPath, SITE_URL).toString();
 
         return (
           <article className="min-h-screen py-24 bg-gray-50 dark:bg-transparent">
@@ -172,13 +173,11 @@ export default function ArticlePageClient({
                   </CyberCard>
                 </div>
 
-                <a
-                  href="https://discourse.aosus.org/"
-                  className="flex items-center gap-2 text-sm font-mono uppercase tracking-wider text-[#008a2f] hover:underline mb-12"
-                >
-                  <MessageSquare className="w-4 h-4" />
-                  {t.discussCta}
-                </a>
+                <DiscourseComments
+                  lang={lang}
+                  isDark={isDark}
+                  embedUrl={discussionEmbedUrl}
+                />
 
                 {prevPost && (
                   <div className="border-t border-[#008a2f]/20 pt-8">

--- a/src/components/DiscourseComments.tsx
+++ b/src/components/DiscourseComments.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ExternalLink, MessageSquare } from "lucide-react";
+import { CyberCard, type Lang } from "@/components/layout/Layout";
+
+const DISCOURSE_URL = "https://discourse.aosus.org";
+const DISCOURSE_ORIGIN = new URL(DISCOURSE_URL).origin;
+
+const LABELS = {
+  en: {
+    eyebrow: "Forum",
+    title: "Comments",
+    subtitle: "Continue the conversation with the Aosus community.",
+    loading: "Loading discussion...",
+    open: "Open full discussion",
+    frameTitle: "Aosus article comments",
+  },
+  ar: {
+    eyebrow: "المنتدى",
+    title: "التعليقات",
+    subtitle: "أكمل النقاش مع مجتمع أسس في المنتدى.",
+    loading: "جاري تحميل النقاش...",
+    open: "افتح النقاش الكامل",
+    frameTitle: "تعليقات مقالة أسس",
+  },
+} satisfies Record<Lang, {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  loading: string;
+  open: string;
+  frameTitle: string;
+}>;
+
+function getFrameTop(frame: HTMLIFrameElement): number {
+  let top = 0;
+  let current: HTMLElement | null = frame;
+
+  while (current) {
+    top += current.offsetTop;
+    current = current.offsetParent as HTMLElement | null;
+  }
+
+  return top;
+}
+
+export default function DiscourseComments({
+  lang,
+  isDark,
+  embedUrl,
+}: {
+  lang: Lang;
+  isDark: boolean;
+  embedUrl: string;
+}) {
+  const t = LABELS[lang];
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = useState(420);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const iframeSrc = useMemo(
+    () => `${DISCOURSE_URL}/embed/comments?embed_url=${encodeURIComponent(embedUrl)}`,
+    [embedUrl],
+  );
+
+  useEffect(() => {
+    setIframeHeight(420);
+    setIsLoaded(false);
+  }, [iframeSrc]);
+
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (event.origin !== DISCOURSE_ORIGIN || !event.data || typeof event.data !== "object") {
+        return;
+      }
+
+      if (event.data.type === "discourse-resize") {
+        const nextHeight = Number(event.data.height);
+
+        if (Number.isFinite(nextHeight) && nextHeight > 0) {
+          setIframeHeight(nextHeight);
+          setIsLoaded(true);
+        }
+
+        return;
+      }
+
+      if (event.data.type === "discourse-scroll") {
+        const nextTop = Number(event.data.top);
+        const frame = iframeRef.current;
+
+        if (!frame || !Number.isFinite(nextTop)) {
+          return;
+        }
+
+        window.scrollTo({ top: getFrameTop(frame) + nextTop, left: 0 });
+      }
+    }
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, []);
+
+  return (
+    <CyberCard isDark={isDark} className="mb-12 overflow-hidden" hover={false}>
+      <div className="border-b border-[#008a2f]/15 bg-[#008a2f]/5 px-5 py-4 dark:bg-[#008a2f]/10">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="mb-1 font-mono text-xs uppercase tracking-[0.24em] text-[#008a2f]">
+              <span className="opacity-50">/</span> {t.eyebrow}
+            </div>
+            <div className="flex items-center gap-2 text-xl font-bold text-gray-900 dark:text-white">
+              <MessageSquare className="h-5 w-5 text-[#008a2f]" />
+              <h2 style={{ fontFamily: lang === "ar" ? "var(--font-arabic)" : undefined }}>
+                {t.title}
+              </h2>
+            </div>
+            <p
+              className="mt-1 text-sm text-gray-600 dark:text-gray-300"
+              style={{ fontFamily: lang === "ar" ? "var(--font-arabic)" : undefined }}
+            >
+              {t.subtitle}
+            </p>
+          </div>
+
+          <a
+            href={DISCOURSE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 self-start text-xs font-mono uppercase tracking-wider text-[#008a2f] hover:underline"
+          >
+            {t.open}
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      </div>
+
+      <div className="relative bg-white dark:bg-black/20">
+        {!isLoaded && (
+          <div className="px-5 py-4 text-xs font-mono uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            {t.loading}
+          </div>
+        )}
+
+        <iframe
+          key={iframeSrc}
+          ref={iframeRef}
+          src={iframeSrc}
+          title={t.frameTitle}
+          className="w-full border-0"
+          style={{ height: `${iframeHeight}px` }}
+          scrolling="no"
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          onLoad={() => setIsLoaded(true)}
+        />
+      </div>
+    </CyberCard>
+  );
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -4,7 +4,7 @@ import matter from "gray-matter";
 import { remark } from "remark";
 import html from "remark-html";
 import { visit } from "unist-util-visit";
-import type { Lang } from "@/lib/locale";
+import { getPostPath, type Lang } from "@/lib/locale";
 import remarkLinkPreviews from "@/lib/remarkLinkPreviews";
 
 export interface PostFrontMatter {
@@ -22,6 +22,7 @@ export interface PostFrontMatter {
   wpId?: string;
   wpType?: string;
   sourceUrl?: string;
+  discussionPath: string;
 }
 
 export const POSTS_PER_PAGE = 9;
@@ -115,6 +116,42 @@ function resolvePublicSlug(data: Record<string, unknown>, directorySlug: string)
   return normalizeString(data.slug) ?? directorySlug;
 }
 
+function readFrontMatterData(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  const fileContents = fs.readFileSync(filePath, "utf8");
+  return matter(fileContents).data;
+}
+
+function resolveDiscussionPath(
+  directorySlug: string,
+  lang: Lang,
+  data: Record<string, unknown>,
+): string {
+  const wpType = normalizeString(data.wpType);
+
+  if (wpType === "post") {
+    const discussionId = normalizeString(data.wpId) ?? resolvePublicSlug(data, directorySlug);
+    return getPostPath("ar", discussionId, true);
+  }
+
+  const discussionLang: Lang = fs.existsSync(getMarkdownFilePath(directorySlug, "ar"))
+    ? "ar"
+    : lang;
+  const discussionData =
+    discussionLang === lang ? data : readFrontMatterData(getMarkdownFilePath(directorySlug, discussionLang));
+  const discussionWpType = normalizeString(discussionData.wpType);
+  const discussionSlug = resolvePublicSlug(discussionData, directorySlug);
+
+  return getPostPath(
+    discussionLang,
+    discussionSlug,
+    discussionWpType === "post" && normalizeString(discussionData.wpId) === discussionSlug,
+  );
+}
+
 function getAllPostDirectories(): string[] {
   if (!fs.existsSync(blogRoot)) {
     return [];
@@ -160,6 +197,7 @@ function parsePostFile(filePath: string, directorySlug: string, lang: Lang): Par
   const wpType = normalizeString(data.wpType);
   const sourceUrl = normalizeString(data.sourceUrl);
   const slug = resolvePublicSlug(data, directorySlug);
+  const discussionPath = resolveDiscussionPath(directorySlug, lang, data);
 
   return {
     filePath,
@@ -180,6 +218,7 @@ function parsePostFile(filePath: string, directorySlug: string, lang: Lang): Par
       wpId,
       wpType,
       sourceUrl,
+      discussionPath,
     } as PostFrontMatter,
     content,
   };


### PR DESCRIPTION
## Summary\n\n- Add client-side Discourse iframe embed component at src/components/DiscourseComments.tsx.\n- Wire it into article pages (ArticlePageClient) and compute canonical discussion paths from post metadata so Arabic and English versions share a thread.\n- Handle iframe resize/scroll via postMessage and use existing CyberCard styling for a lightweight native wrapper.\n\n## Files changed\n\n- src/components/DiscourseComments.tsx (new)\n- src/lib/markdown.ts (adds discussionPath resolution)\n- src/app/(en)/blog/[slug]/ArticlePageClient.tsx (renders the embed)\n\n## Testing & Notes\n\n- pnpm build completed successfully in CI-local run.\n- The embedded iframe uses https://discourse.aosus.org/embed/comments?embed_url= with a canonical URL derived from post metadata. The fallback "Open full discussion" currently links to the forum root; deep links to topics would require persisting topic IDs or using Discourse API in a follow-up.\n