### PR TITLE
feat: add lazy Discourse comments to blog posts

### DIFF
--- a/content/blog/README.md
+++ b/content/blog/README.md
@@ -15,3 +15,9 @@ image: "cover.png"
 ```
 
 The build rewrites those paths so they work in the exported site.
+
+Discourse comments are opt-in per post. Add this to a post's front matter only when you want the site to create and embed a Discourse discussion for that article:
+
+```yaml
+commentsEnabled: true
+```

--- a/src/app/(en)/blog/[slug]/ArticlePageClient.tsx
+++ b/src/app/(en)/blog/[slug]/ArticlePageClient.tsx
@@ -242,7 +242,9 @@ export default function ArticlePageClient({
                   </CyberCard>
                 </div>
 
-                <DiscourseComments lang={lang} articleUrl={articleUrl} />
+                {post.commentsEnabled && (
+                  <DiscourseComments lang={lang} articleUrl={articleUrl} />
+                )}
 
                 {prevPost && (
                   <div className="border-t border-[#008a2f]/20 pt-8">

--- a/src/app/(en)/blog/[slug]/ArticlePageClient.tsx
+++ b/src/app/(en)/blog/[slug]/ArticlePageClient.tsx
@@ -7,11 +7,11 @@ import {
   User,
   ArrowLeft,
   ArrowRight,
-  MessageSquare,
   Tag,
 } from "lucide-react";
 import Link from "next/link";
 import CommunityLinks from "@/components/CommunityLinks";
+import DiscourseComments from "@/components/DiscourseComments";
 import Layout, {
   CyberCard,
   PrimaryButton,
@@ -26,14 +26,12 @@ const LABELS = {
   en: {
     breadcrumb: ["Home", "Blog"],
     supportCta: "Support Aosus Community",
-    discussCta: "Discuss on Forum",
     prevLabel: "Previous Post",
     supportBtn: "Support Us",
   },
   ar: {
     breadcrumb: ["الرئيسية", "المدونة"],
     supportCta: "ادعم مجتمع أسس",
-    discussCta: "علّق في المنتدى",
     prevLabel: "المقال السابق",
     supportBtn: "ادعمنا",
   },
@@ -244,13 +242,7 @@ export default function ArticlePageClient({
                   </CyberCard>
                 </div>
 
-                <a
-                  href="https://discourse.aosus.org/"
-                  className="flex items-center gap-2 text-sm font-mono uppercase tracking-wider text-[#008a2f] hover:underline mb-12"
-                >
-                  <MessageSquare className="w-4 h-4" />
-                  {t.discussCta}
-                </a>
+                <DiscourseComments lang={lang} articleUrl={articleUrl} />
 
                 {prevPost && (
                   <div className="border-t border-[#008a2f]/20 pt-8">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,6 +114,54 @@
   --font-mono: "Kawkab Mono", ui-monospace, monospace;
 }
 
+.aosus-discourse-comments__shell {
+  border: 1px solid color-mix(in srgb, #008a2f 28%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #008a2f 5%, white), rgba(255, 255, 255, 0.92)),
+    linear-gradient(135deg, rgba(29, 112, 186, 0.08), transparent 42%);
+  padding: 1.5rem;
+  box-shadow: 0 24px 60px rgba(2, 8, 23, 0.06);
+}
+
+.dark .aosus-discourse-comments__shell {
+  background:
+    linear-gradient(180deg, rgba(2, 6, 23, 0.9), rgba(0, 0, 0, 0.92)),
+    linear-gradient(135deg, rgba(29, 112, 186, 0.14), transparent 45%);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+}
+
+.aosus-discourse-comments__placeholder {
+  margin-top: 1.5rem;
+  display: flex;
+  min-height: 7rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  border: 1px dashed color-mix(in srgb, #008a2f 28%, transparent);
+  background: color-mix(in srgb, #008a2f 4%, white);
+  padding: 1rem 1.25rem;
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgb(75 85 99);
+}
+
+.dark .aosus-discourse-comments__placeholder {
+  background: color-mix(in srgb, #008a2f 8%, black);
+  color: rgb(209 213 219);
+}
+
+.aosus-discourse-comments__mount {
+  margin-top: 1.5rem;
+  min-height: 1px;
+}
+
+.aosus-discourse-comments__mount iframe {
+  width: 100%;
+  border: 0;
+  background: transparent;
+}
+
 .aosus-link-preview-inline {
   position: relative;
   display: inline-flex;

--- a/src/components/DiscourseComments.tsx
+++ b/src/components/DiscourseComments.tsx
@@ -60,6 +60,7 @@ export default function DiscourseComments({
   const isRtl = lang === "ar";
   const shellFont = isRtl ? "var(--font-arabic)" : undefined;
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const resetInProgressRef = React.useRef(false);
   const [isActivated, setIsActivated] = React.useState(false);
   const [status, setStatus] = React.useState<"idle" | "loading" | "ready" | "error">("idle");
 
@@ -88,6 +89,7 @@ export default function DiscourseComments({
     let observer: IntersectionObserver | null = null;
 
     const activate = () => {
+      resetInProgressRef.current = false;
       setIsActivated(true);
     };
 
@@ -142,6 +144,10 @@ export default function DiscourseComments({
       return;
     }
 
+    if (resetInProgressRef.current) {
+      return;
+    }
+
     let isCancelled = false;
     setStatus("loading");
     node.innerHTML = "";
@@ -176,9 +182,11 @@ export default function DiscourseComments({
     };
 
     document.head.appendChild(script);
+    resetInProgressRef.current = false;
 
     return () => {
       isCancelled = true;
+      resetInProgressRef.current = true;
       script.remove();
 
       if (window.DiscourseEmbed?.discourseEmbedUrl === articleUrl) {

--- a/src/components/DiscourseComments.tsx
+++ b/src/components/DiscourseComments.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import React from "react";
+import { ExternalLink, LoaderCircle, MessageSquare } from "lucide-react";
+import { PrimaryButton } from "@/components/layout/Layout";
+import type { Lang } from "@/lib/locale";
+
+export const DISCOURSE_URL = "https://discourse.aosus.org/";
+
+const EMBED_SCRIPT_ID = "aosus-discourse-embed-script";
+const EMBED_ROOT_ID = "discourse-comments";
+
+const COPY = {
+  en: {
+    title: "Comments",
+    subtitle: "Read the discussion here and jump to the forum for the full reply editor.",
+    action: "Open Forum",
+    idle: "Comments load only when you get here, so the article stays fast.",
+    loading: "Loading the discussion from Discourse...",
+    error: "The embedded discussion could not be loaded right now.",
+    fallback: "Continue the discussion on the Aosus forum",
+  },
+  ar: {
+    title: "التعليقات",
+    subtitle: "اقرأ النقاش هنا وانتقل إلى المنتدى لكتابة رد كامل.",
+    action: "افتح المنتدى",
+    idle: "تُحمّل التعليقات عند الوصول إلى هذا القسم فقط للحفاظ على سرعة الصفحة.",
+    loading: "جارٍ تحميل النقاش من ديسكورس...",
+    error: "تعذّر تحميل النقاش المضمّن الآن.",
+    fallback: "تابع النقاش في منتدى أسس",
+  },
+} as const;
+
+type DiscourseEmbedConfig = {
+  discourseUrl: string;
+  discourseEmbedUrl: string;
+  fullApp?: boolean;
+  dynamicHeight?: boolean;
+  embedMinHeight?: string;
+  embedMaxHeight?: string;
+  className?: string;
+  discourseReferrerPolicy?: string;
+};
+
+declare global {
+  interface Window {
+    DiscourseEmbed?: DiscourseEmbedConfig;
+  }
+}
+
+export default function DiscourseComments({
+  lang,
+  articleUrl,
+}: {
+  lang: Lang;
+  articleUrl: string;
+}) {
+  const t = COPY[lang];
+  const titleId = React.useId();
+  const isRtl = lang === "ar";
+  const shellFont = isRtl ? "var(--font-arabic)" : undefined;
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [isActivated, setIsActivated] = React.useState(false);
+  const [status, setStatus] = React.useState<"idle" | "loading" | "ready" | "error">("idle");
+
+  React.useEffect(() => {
+    setIsActivated(false);
+    setStatus("idle");
+
+    if (containerRef.current) {
+      containerRef.current.innerHTML = "";
+    }
+  }, [articleUrl]);
+
+  React.useEffect(() => {
+    if (isActivated) {
+      return;
+    }
+
+    const node = containerRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    let timeoutId: number | undefined;
+    let idleId: number | undefined;
+    let observer: IntersectionObserver | null = null;
+
+    const activate = () => {
+      setIsActivated(true);
+    };
+
+    const scheduleActivation = () => {
+      if (typeof window.requestIdleCallback === "function") {
+        idleId = window.requestIdleCallback(() => activate(), { timeout: 800 });
+        return;
+      }
+
+      timeoutId = window.setTimeout(activate, 0);
+    };
+
+    if (typeof window.IntersectionObserver !== "function") {
+      scheduleActivation();
+    } else {
+      observer = new window.IntersectionObserver(
+        (entries) => {
+          if (!entries[0]?.isIntersecting) {
+            return;
+          }
+
+          observer?.disconnect();
+          scheduleActivation();
+        },
+        { rootMargin: "320px 0px" },
+      );
+
+      observer.observe(node);
+    }
+
+    return () => {
+      observer?.disconnect();
+
+      if (typeof timeoutId === "number") {
+        window.clearTimeout(timeoutId);
+      }
+
+      if (typeof idleId === "number" && typeof window.cancelIdleCallback === "function") {
+        window.cancelIdleCallback(idleId);
+      }
+    };
+  }, [isActivated]);
+
+  React.useEffect(() => {
+    if (!isActivated) {
+      return;
+    }
+
+    const node = containerRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    let isCancelled = false;
+    setStatus("loading");
+    node.innerHTML = "";
+
+    window.DiscourseEmbed = {
+      discourseUrl: DISCOURSE_URL,
+      discourseEmbedUrl: articleUrl,
+      fullApp: true,
+      dynamicHeight: true,
+      embedMinHeight: "360",
+      embedMaxHeight: "1400",
+      className: "aosus-discourse-embed",
+      discourseReferrerPolicy: "strict-origin-when-cross-origin",
+    };
+
+    document.getElementById(EMBED_SCRIPT_ID)?.remove();
+
+    const script = document.createElement("script");
+    script.id = EMBED_SCRIPT_ID;
+    script.type = "text/javascript";
+    script.async = true;
+    script.src = `${DISCOURSE_URL}javascripts/embed.js`;
+    script.onload = () => {
+      if (!isCancelled) {
+        setStatus("ready");
+      }
+    };
+    script.onerror = () => {
+      if (!isCancelled) {
+        setStatus("error");
+      }
+    };
+
+    document.head.appendChild(script);
+
+    return () => {
+      isCancelled = true;
+      script.remove();
+
+      if (window.DiscourseEmbed?.discourseEmbedUrl === articleUrl) {
+        delete window.DiscourseEmbed;
+      }
+    };
+  }, [articleUrl, isActivated]);
+
+  const statusText =
+    status === "error" ? t.error : status === "loading" ? t.loading : t.idle;
+
+  return (
+    <section className="aosus-discourse-comments mb-12" aria-labelledby={titleId}>
+      <div className="aosus-discourse-comments__shell">
+        <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-3">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-[#008a2f]">
+              <span className="opacity-50">/</span> forum
+            </p>
+            <div className="space-y-2">
+              <h2
+                id={titleId}
+                className="flex items-center gap-2 text-2xl font-bold text-gray-900 dark:text-white"
+                style={{ fontFamily: shellFont }}
+              >
+                <MessageSquare className="h-5 w-5 text-[#008a2f]" />
+                {t.title}
+              </h2>
+              <p
+                className="max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-300"
+                style={{ fontFamily: shellFont }}
+              >
+                {t.subtitle}
+              </p>
+            </div>
+          </div>
+
+          <PrimaryButton
+            href={DISCOURSE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0"
+          >
+            {t.action}
+            <ExternalLink className="h-4 w-4" />
+          </PrimaryButton>
+        </div>
+
+        {status !== "ready" && (
+          <div className="aosus-discourse-comments__placeholder" aria-live="polite">
+            {status === "loading" && <LoaderCircle className="h-5 w-5 animate-spin text-[#008a2f]" />}
+            <p style={{ fontFamily: shellFont }}>{statusText}</p>
+          </div>
+        )}
+
+        <div
+          ref={containerRef}
+          id={EMBED_ROOT_ID}
+          className="aosus-discourse-comments__mount"
+          aria-busy={status === "loading"}
+        />
+
+        <noscript>
+          <p className="mt-4 text-sm text-gray-600">
+            <a href={DISCOURSE_URL} className="text-[#008a2f] underline underline-offset-4">
+              {t.fallback}
+            </a>
+          </p>
+        </noscript>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -13,6 +13,7 @@ export interface PostFrontMatter {
   author: string;
   tags: string[];
   categories: string[];
+  commentsEnabled: boolean;
   image: string;
   thumbnail?: string;
   ogImage: string;
@@ -105,6 +106,23 @@ function normalizeString(value: unknown): string | undefined {
   return undefined;
 }
 
+function normalizeBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "yes" || normalized === "1";
+  }
+
+  if (typeof value === "number") {
+    return value === 1;
+  }
+
+  return false;
+}
+
 function resolvePublicSlug(data: Record<string, unknown>, directorySlug: string): string {
   const wpType = normalizeString(data.wpType);
 
@@ -169,6 +187,7 @@ function parsePostFile(filePath: string, directorySlug: string, lang: Lang): Par
       author: data.author || "",
       tags,
       categories,
+      commentsEnabled: normalizeBoolean(data.commentsEnabled),
       image: resolvePostAssetUrl(filePath, imageSource),
       thumbnail: thumbnailSource
         ? resolvePostAssetUrl(filePath, thumbnailSource)

--- a/test/article-page-social-banners.test.tsx
+++ b/test/article-page-social-banners.test.tsx
@@ -43,6 +43,7 @@ describe("ArticlePageClient social banners", () => {
     image: "/image.png",
     content: "<p>Body</p>",
     tags: ["tag"],
+    commentsEnabled: false,
   } as any;
 
   it("renders compressed one-row icon banners for chat and social links", () => {
@@ -74,7 +75,13 @@ describe("ArticlePageClient social banners", () => {
   });
 
   it("renders a lazy discourse comments shell with a forum fallback action", () => {
-    render(<ArticlePageClient post={post} prevPost={null} lang="en" />);
+    render(
+      <ArticlePageClient
+        post={{ ...post, commentsEnabled: true }}
+        prevPost={null}
+        lang="en"
+      />,
+    );
 
     expect(screen.getByRole("heading", { name: "Comments" })).toBeInTheDocument();
     expect(screen.getByText(/Comments load only when you get here/i)).toBeInTheDocument();
@@ -82,5 +89,12 @@ describe("ArticlePageClient social banners", () => {
       "href",
       "https://discourse.aosus.org/",
     );
+  });
+
+  it("does not render discourse comments when the post has not opted in", () => {
+    render(<ArticlePageClient post={post} prevPost={null} lang="en" />);
+
+    expect(screen.queryByRole("heading", { name: "Comments" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Open Forum/i })).not.toBeInTheDocument();
   });
 });

--- a/test/article-page-social-banners.test.tsx
+++ b/test/article-page-social-banners.test.tsx
@@ -72,4 +72,15 @@ describe("ArticlePageClient social banners", () => {
     expect(screen.queryByText(/Join our chat rooms/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Follow our social media accounts/i)).not.toBeInTheDocument();
   });
+
+  it("renders a lazy discourse comments shell with a forum fallback action", () => {
+    render(<ArticlePageClient post={post} prevPost={null} lang="en" />);
+
+    expect(screen.getByRole("heading", { name: "Comments" })).toBeInTheDocument();
+    expect(screen.getByText(/Comments load only when you get here/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open Forum/i })).toHaveAttribute(
+      "href",
+      "https://discourse.aosus.org/",
+    );
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 export default defineConfig({
   plugins: [react()],
+  publicDir: false,
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -36,7 +36,8 @@ if (!window.IntersectionObserver) {
     unobserve() {}
   }
 
-  window.IntersectionObserver = MockIntersectionObserver as any;
+  window.IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
 }
 
 HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as any;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,10 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});
 
 if (!window.matchMedia) {
   window.matchMedia = vi.fn().mockImplementation(() => ({
@@ -12,6 +17,26 @@ if (!window.matchMedia) {
     removeListener: vi.fn(),
     dispatchEvent: vi.fn(),
   }));
+}
+
+if (!window.IntersectionObserver) {
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = null;
+    readonly rootMargin = "0px";
+    readonly thresholds = [];
+
+    disconnect() {}
+
+    observe() {}
+
+    takeRecords() {
+      return [];
+    }
+
+    unobserve() {}
+  }
+
+  window.IntersectionObserver = MockIntersectionObserver as any;
 }
 
 HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as any;


### PR DESCRIPTION
## Summary
- add a Discourse comments section to article pages using the official embed script, with lazy client-side loading so comments only initialize near the viewport
- keep the article itself fully statically rendered for SEO, add a native-looking comments shell and a direct forum fallback action
- extend tests and Vitest setup so the comments UI is covered and test runs no longer scan generated public assets

## Verification
- npm test
- npm run build